### PR TITLE
Use string type for id in miniSearch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diet-diary",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diet-diary",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diet-diary",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/features/suggestions/generate/autoSuggestion.ts
+++ b/src/features/suggestions/generate/autoSuggestion.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Suggestion } from "../Suggestion";
 import baseOn from './calculateServing';
-import { PredefinedSuggestion } from '../search/foodNameSearch';
+import { PredefinedSuggestion } from "../search/PredefinedSuggestion";
 
 export function generateAutoSuggestion(autoCompletion: Suggestion, suggestions: PredefinedSuggestion[]) {
   if (_.size(suggestions) === 0) return null;

--- a/src/features/suggestions/search/PredefinedSuggestion.ts
+++ b/src/features/suggestions/search/PredefinedSuggestion.ts
@@ -1,0 +1,9 @@
+import { Serving } from "../../../model/Food";
+
+
+export interface PredefinedSuggestion {
+  foodName: string;
+  amount: string;
+  serving: Serving;
+  bestChoice?: boolean;
+}

--- a/src/features/suggestions/search/foodNameMiniSearch.ts
+++ b/src/features/suggestions/search/foodNameMiniSearch.ts
@@ -10,7 +10,14 @@ function find(dict: Dictionary<PredefinedSuggestion>, res: SearchResult) {
 
 export function buildDocuments(list: PredefinedSuggestion[]) {
   const miniSearch = new MiniSearch({
-    fields: ['foodName']
+    fields: ['foodName'],
+    storeFields: [
+      'foodName',
+      'amount',
+      'serving',
+      'bestChoice',
+    ]
+
   })
 
   miniSearch.addAll(_.map(list, addIndexAsId));
@@ -25,12 +32,21 @@ function perform(miniSearch: MiniSearch<PredefinedSuggestion>, foodName: string)
   return miniSearch.search(foodName, options);
 }
 
+function toSuggestion(res: SearchResult): PredefinedSuggestion {
+  return {
+    foodName: _.get(res, 'foodName'),
+    amount: _.get(res, 'amount'),
+    serving: _.get(res, 'serving'),
+    bestChoice: _.get(res, 'bestChoice'),
+  }
+}
+
 export function search(
   docs: { miniSearch: MiniSearch<PredefinedSuggestion>, lookUp: (res: SearchResult) => PredefinedSuggestion },
   foodName: string
 ) {
-  const { miniSearch, lookUp } = docs;
-  return _.map(perform(miniSearch, foodName), lookUp);
+  const { miniSearch } = docs;
+  return _.map(perform(miniSearch, foodName), toSuggestion);
 }
 
 export function autoSuggest<T>(

--- a/src/features/suggestions/search/foodNameMiniSearch.ts
+++ b/src/features/suggestions/search/foodNameMiniSearch.ts
@@ -1,13 +1,14 @@
 import _ from 'lodash';
 import MiniSearch, { SearchOptions, SearchResult } from 'minisearch';
+import { PredefinedSuggestion } from './PredefinedSuggestion';
 
 function addIndexAsId(obj: object, i: number) { return _.set(obj, "id", i); }
 
-function find<T>(list: T[], res: SearchResult) {
+function find(list: PredefinedSuggestion[], res: SearchResult) {
   return list[res.id];
 }
 
-export function buildDocuments<T extends { foodName: string; }>(list: T[]) {
+export function buildDocuments(list: PredefinedSuggestion[]) {
   const miniSearch = new MiniSearch({
     fields: ['foodName']
   })
@@ -19,13 +20,13 @@ export function buildDocuments<T extends { foodName: string; }>(list: T[]) {
   }
 }
 
-function perform<T>(miniSearch: MiniSearch<T>, foodName: string) {
+function perform(miniSearch: MiniSearch<PredefinedSuggestion>, foodName: string) {
   const options = { fuzzy: true };
   return miniSearch.search(foodName, options);
 }
 
-export function search<T>(
-  docs: { miniSearch: MiniSearch<T>, lookUp: (res: SearchResult) => T },
+export function search(
+  docs: { miniSearch: MiniSearch<PredefinedSuggestion>, lookUp: (res: SearchResult) => PredefinedSuggestion },
   foodName: string
 ) {
   const { miniSearch, lookUp } = docs;

--- a/src/features/suggestions/search/foodNameMiniSearch.ts
+++ b/src/features/suggestions/search/foodNameMiniSearch.ts
@@ -1,12 +1,8 @@
-import _, { Dictionary } from 'lodash';
+import _ from 'lodash';
 import MiniSearch, { SearchOptions, SearchResult } from 'minisearch';
 import { PredefinedSuggestion } from './PredefinedSuggestion';
 
 function addIndexAsId(obj: object, i: number) { return _.set(obj, "id", _.toString(i)); }
-
-function find(dict: Dictionary<PredefinedSuggestion>, res: SearchResult) {
-  return dict[res.id];
-}
 
 export function buildDocuments(list: PredefinedSuggestion[]) {
   const miniSearch = new MiniSearch({
@@ -22,8 +18,7 @@ export function buildDocuments(list: PredefinedSuggestion[]) {
 
   miniSearch.addAll(_.map(list, addIndexAsId));
   return {
-    miniSearch,
-    lookUp: _.partial(find, _.keyBy(list, 'id')),
+    miniSearch
   }
 }
 

--- a/src/features/suggestions/search/foodNameMiniSearch.ts
+++ b/src/features/suggestions/search/foodNameMiniSearch.ts
@@ -1,11 +1,11 @@
-import _ from 'lodash';
+import _, { Dictionary } from 'lodash';
 import MiniSearch, { SearchOptions, SearchResult } from 'minisearch';
 import { PredefinedSuggestion } from './PredefinedSuggestion';
 
-function addIndexAsId(obj: object, i: number) { return _.set(obj, "id", i); }
+function addIndexAsId(obj: object, i: number) { return _.set(obj, "id", _.toString(i)); }
 
-function find(list: PredefinedSuggestion[], res: SearchResult) {
-  return list[res.id];
+function find(dict: Dictionary<PredefinedSuggestion>, res: SearchResult) {
+  return dict[res.id];
 }
 
 export function buildDocuments(list: PredefinedSuggestion[]) {
@@ -16,7 +16,7 @@ export function buildDocuments(list: PredefinedSuggestion[]) {
   miniSearch.addAll(_.map(list, addIndexAsId));
   return {
     miniSearch,
-    lookUp: _.partial(find, list),
+    lookUp: _.partial(find, _.keyBy(list, 'id')),
   }
 }
 

--- a/src/features/suggestions/search/foodNameMiniSearch.ts
+++ b/src/features/suggestions/search/foodNameMiniSearch.ts
@@ -37,7 +37,7 @@ function toSuggestion(res: SearchResult): PredefinedSuggestion {
 }
 
 export function search(
-  docs: { miniSearch: MiniSearch<PredefinedSuggestion>, lookUp: (res: SearchResult) => PredefinedSuggestion },
+  docs: { miniSearch: MiniSearch<PredefinedSuggestion> },
   foodName: string
 ) {
   const { miniSearch } = docs;

--- a/src/features/suggestions/search/foodNameSearch.ts
+++ b/src/features/suggestions/search/foodNameSearch.ts
@@ -6,7 +6,7 @@ import parseAmount from "../parser/DecomposedAmount";
 import { isMeasurementConvertible, Unit } from "../convert";
 import { PredefinedSuggestion } from "./PredefinedSuggestion";
 
-const suggestions = buildDocuments<PredefinedSuggestion>(_.concat(servings, portions));
+const suggestions = buildDocuments(_.concat(servings, portions));
 
 const searchFoodServingPortionSize = (foodName: string) =>
   search(suggestions, foodName);

--- a/src/features/suggestions/search/foodNameSearch.ts
+++ b/src/features/suggestions/search/foodNameSearch.ts
@@ -1,17 +1,10 @@
 import _ from "lodash";
-import { Serving } from "../../../model/Food";
 import portions from "../portion/portions";
 import { buildDocuments, search, autoSuggest } from "./foodNameMiniSearch";
 import servings from "../serving/servings";
 import parseAmount from "../parser/DecomposedAmount";
 import { isMeasurementConvertible, Unit } from "../convert";
-
-export interface PredefinedSuggestion {
-  foodName: string;
-  amount: string;
-  serving: Serving;
-  bestChoice?: boolean;
-}
+import { PredefinedSuggestion } from "./PredefinedSuggestion";
 
 const suggestions = buildDocuments<PredefinedSuggestion>(_.concat(servings, portions));
 

--- a/src/features/suggestions/search/foodNameSearch.ts
+++ b/src/features/suggestions/search/foodNameSearch.ts
@@ -1,9 +1,9 @@
 import _ from "lodash";
-import portions from "../portion/portions";
-import { buildDocuments, search, autoSuggest } from "./foodNameMiniSearch";
-import servings from "../serving/servings";
-import parseAmount from "../parser/DecomposedAmount";
 import { isMeasurementConvertible, Unit } from "../convert";
+import parseAmount from "../parser/DecomposedAmount";
+import portions from "../portion/portions";
+import servings from "../serving/servings";
+import { autoSuggest, buildDocuments, search } from "./foodNameMiniSearch";
 import { PredefinedSuggestion } from "./PredefinedSuggestion";
 
 const suggestions = buildDocuments(_.concat(servings, portions));


### PR DESCRIPTION
- To use hash code as id later
- Store fields with search results instead of keeping in a list