### PR TITLE
Do not show target icons on Best Choice tab

### DIFF
--- a/src/features/summary/ServingCell.ts
+++ b/src/features/summary/ServingCell.ts
@@ -1,11 +1,11 @@
 import { connect } from "react-redux";
-import { targetSelector } from "../../app/selectors";
+import { summaryTypeSelector, targetSelector } from "../../app/selectors";
 import { RootState } from "../../app/store";
 import { ServingCell } from "../../components/summary/ServingCell";
 import { hasATarget } from "../../model/Target";
 
 const mapStateToProps = (state: RootState) => ({
-  showTargetActionIcon: hasATarget(targetSelector(state)),
+  showTargetActionIcon: hasATarget(targetSelector(state)) && summaryTypeSelector(state) != 'best-choice-percentage',
 })
 
 export default connect(mapStateToProps)(ServingCell);


### PR DESCRIPTION
Target icons are not relevant on this tab and they are confusing.