### PR TITLE
Match prep method on search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diet-diary",
-  "version": "2.26.4",
+  "version": "2.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diet-diary",
-      "version": "2.26.4",
+      "version": "2.27.0",
       "workspaces": [
         "packages/parser"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diet-diary",
-  "version": "2.26.4",
+  "version": "2.27.0",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -5,13 +5,6 @@ import parseAmount, { DecomposedAmount } from '../parser/DecomposedAmount';
 import convert, { isMeasurementConvertible, Unit } from '../convert';
 
 function measurementFor(unit: Unit, { measurement, alternateMeasurement }: DecomposedAmount) {
-  if (unit === "unknown") {
-    if (alternateMeasurement && alternateMeasurement.unit === "unknown") {
-      return alternateMeasurement;
-    }
-    return measurement;
-  };
-
   const isUnitConvertibleTo = _.partial(isMeasurementConvertible, unit);
   const allMeasurements = alternateMeasurement ? [measurement, alternateMeasurement] : [measurement];
   const found = _.filter(allMeasurements, isUnitConvertibleTo);

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -13,12 +13,13 @@ function measurementFor(unit: Unit, { measurement, alternateMeasurement }: Decom
   };
 
   const isUnitConvertibleTo = _.partial(isMeasurementConvertible, unit);
-  if (isUnitConvertibleTo(measurement)) {
+  const allMeasurements = alternateMeasurement ? [measurement, alternateMeasurement] : [measurement];
+  const found = _.filter(allMeasurements, isUnitConvertibleTo);
+  if (found) {
+    return found[0] as typeof measurement;
+  } else {
     return measurement;
-  } else if (alternateMeasurement && isUnitConvertibleTo(alternateMeasurement)) {
-    return alternateMeasurement;
   }
-  return measurement;
 }
 
 function servingFor(unitServing: Serving, servingAmount: DecomposedAmount, amount: string) {

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -14,9 +14,9 @@ function measurementFor(unit: Unit, { measurement, alternateMeasurement }: Decom
       const words = _.words(_.lowerCase(m.unitText));
       return _.includes(words, prepMethod);
     }
-    const hasPrepMethod = _.filter(canBeConverted, containsPrepMethod);
-    if (hasPrepMethod) {
-      return _.defaultTo(_.head(hasPrepMethod), measurement);
+    const matchedPrepMethod = _.filter(canBeConverted, containsPrepMethod);
+    if (matchedPrepMethod) {
+      return _.defaultTo(_.head(matchedPrepMethod), measurement);
     }
   }
   return _.defaultTo(_.head(canBeConverted), measurement);

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -9,7 +9,7 @@ function measurementFor(unit: Unit, { measurement, alternateMeasurement }: Decom
   const allMeasurements = alternateMeasurement ? [measurement, alternateMeasurement] : [measurement];
   const found = _.filter(allMeasurements, isUnitConvertibleTo);
   if (found) {
-    return found[0] as typeof measurement;
+    return found[0];
   } else {
     return measurement;
   }

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -8,11 +8,7 @@ function measurementFor(unit: Unit, { measurement, alternateMeasurement }: Decom
   const isUnitConvertibleTo = _.partial(isMeasurementConvertible, unit);
   const allMeasurements = alternateMeasurement ? [measurement, alternateMeasurement] : [measurement];
   const found = _.filter(allMeasurements, isUnitConvertibleTo);
-  if (found) {
-    return found[0];
-  } else {
-    return measurement;
-  }
+  return _.defaultTo(_.head(found), measurement);
 }
 
 function servingFor(unitServing: Serving, servingAmount: DecomposedAmount, amount: string) {

--- a/src/features/suggestions/generate/calculateServing.ts
+++ b/src/features/suggestions/generate/calculateServing.ts
@@ -7,8 +7,8 @@ import convert, { isMeasurementConvertible, Unit } from '../convert';
 function measurementFor(unit: Unit, { measurement, alternateMeasurement }: DecomposedAmount) {
   const isUnitConvertibleTo = _.partial(isMeasurementConvertible, unit);
   const allMeasurements = alternateMeasurement ? [measurement, alternateMeasurement] : [measurement];
-  const found = _.filter(allMeasurements, isUnitConvertibleTo);
-  return _.defaultTo(_.head(found), measurement);
+  const canBeConverted = _.filter(allMeasurements, isUnitConvertibleTo);
+  return _.defaultTo(_.head(canBeConverted), measurement);
 }
 
 function servingFor(unitServing: Serving, servingAmount: DecomposedAmount, amount: string) {

--- a/src/features/suggestions/generate/generateSuggestion.test.ts
+++ b/src/features/suggestions/generate/generateSuggestion.test.ts
@@ -311,3 +311,28 @@ test("diameter size calculation", () => {
   generateSuggestions(new MockRefObject("cheese pizza 1/8 of 12-inch "), assert);
 
 })
+
+test("use prep method -- word after unit e.g. 1 cup cooked to determine the measurement", () => {
+  const assert = (suggestions: Suggestion[]) => {
+    expect(_.size(suggestions)).toBeGreaterThanOrEqual(2);
+    // the input
+    expect(suggestions[0]).toEqual(
+      {
+        foodName: "cabbage, green or red",
+        amount: "1 cup cooked",
+      }
+    );
+    expect(suggestions[1]).toMatchObject(
+      {
+        foodName: "cabbage, green or red",
+        amount: "1 cup cooked",
+        serving: {
+          "vegetable": 2,
+        }
+      }
+    );
+
+  }
+  generateSuggestions(new MockRefObject("cabbage, green or red 1 cup cooked"), assert);
+
+})


### PR DESCRIPTION
If prep method is included after unit e.g. "2 cup chopped or 1 cup cooked", search should match on the prep method.