### PR TITLE
Revert back to draft release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ name: Deploy Next.js site to Pages
 
 on:
   release:
+    types: [published]
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Release
+name: Draft Release
 on:
   push:
     branches: [ main ]
@@ -28,5 +28,3 @@ jobs:
           last_commit_message=$(git log -1 --pretty=%B)
           # Create a release as draft
           gh release create "$tag" --title "$tag $last_commit_message" --generate-notes --notes-start-tag "$latest_tag" --draft
-          # publish the release
-          gh release edit "$tag" --draft=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diet-diary",
-  "version": "2.45.3",
+  "version": "2.45.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diet-diary",
-      "version": "2.45.3",
+      "version": "2.45.4",
       "workspaces": [
         "packages/parser"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diet-diary",
-  "version": "2.45.3",
+  "version": "2.45.4",
   "private": true,
   "homepage": ".",
   "dependencies": {


### PR DESCRIPTION
Publish release through gh cli does not trigger workflow. Use web UI to publish as before.