### PR TITLE
Revert back deploy on tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,9 @@ name: Deploy Next.js site to Pages
 
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches: [ main ]
   release:
-    types:
-      - published
+    types: [published]
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ concurrency:
 jobs:
   # Build job
   build:
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diet-diary",
-  "version": "2.45.6",
+  "version": "2.45.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diet-diary",
-      "version": "2.45.6",
+      "version": "2.45.7",
       "workspaces": [
         "packages/parser"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diet-diary",
-  "version": "2.45.6",
+  "version": "2.45.7",
   "private": true,
   "homepage": ".",
   "dependencies": {


### PR DESCRIPTION
Adding new tag when creating a release does not trigger tag push event.